### PR TITLE
fix next version conflict

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "analyze": "size-limit --why"
   },
   "peerDependencies": {
+    "next": ">=13",
     "react": ">=16"
   },
   "husky": {
@@ -51,6 +52,7 @@
     "@types/react": "^18.0.27",
     "@types/react-dom": "^18.0.10",
     "husky": "^8.0.3",
+    "next": "^13.1.6",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "size-limit": "^8.1.2",
@@ -61,7 +63,6 @@
   "dependencies": {
     "find-yarn-workspace-root": "^2.0.0",
     "fs-extra": "^11.1.0",
-    "next": "^13.1.6",
     "next-compose-plugins": "^2.2.1",
     "next-transpile-modules": "^10.0.0"
   }


### PR DESCRIPTION
This fixes the conflict between Next.js versions logged during Next dev and build commands.

<img width="1108" alt="Screenshot 2024-09-01 at 19 05 01" src="https://github.com/user-attachments/assets/505970f6-ccf3-4df6-ab34-a8a77d043503">
